### PR TITLE
save missing packages infomation

### DIFF
--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -49,7 +49,7 @@ SyncSettings =
   checkFoPackageNeedInstall: (cb=null) ->
     filePath = atom.config.configDirPath + "/" + MISSING_PACKAGES_JSON
 
-    fs.exists filePath, (exists)=>
+    fs.exists filePath, (exists) =>
       if exists
         fileContent = @fileContent filePath
         list = JSON.parse fileContent
@@ -161,7 +161,7 @@ SyncSettings =
     Shell.openExternal "https://gist.github.com/#{gistId}"
 
   getPackages: ->
-    for own name, info of(atom.packages.getLoadedPackages().filter (x)-> not x.bundledPackage)
+    for own name, info of(atom.packages.getLoadedPackages().filter (x) -> not x.bundledPackage)
       {name, version, theme} = info.metadata
       {name, version, theme}
 

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -148,7 +148,7 @@ SyncSettings =
     Shell.openExternal "https://gist.github.com/#{gistId}"
 
   getPackages: ->
-    for own name, info of atom.packages.getLoadedPackages()
+    for own name, info of(atom.packages.getLoadedPackages().filter (x)-> not x.bundledPackage)
       {name, version, theme} = info.metadata
       {name, version, theme}
 


### PR DESCRIPTION
Sometimes restore the config，some packages can't be installed because of networking or Atom.app be killed. So I save the missing packages info, when atom start, auto to check and install it.
