### PR TITLE
Allow syncing git-installed packages

### DIFF
--- a/lib/package-manager.coffee
+++ b/lib/package-manager.coffee
@@ -151,13 +151,16 @@ class PackageManager
     @runCommand(args, exit)
 
   install: (pack, callback) ->
-    {name, version, theme} = pack
+    {name, version, theme, apmInstallSource} = pack
     activateOnSuccess = not theme and not atom.packages.isPackageDisabled(name)
     activateOnFailure = atom.packages.isPackageActive(name)
     atom.packages.deactivatePackage(name) if atom.packages.isPackageActive(name)
     atom.packages.unloadPackage(name) if atom.packages.isPackageLoaded(name)
 
-    args = ['install', "#{name}@#{version}"]
+    packageRef =
+      if apmInstallSource then apmInstallSource.source
+      else "#{name}@#{version}"
+    args = ['install', packageRef]
     exit = (code, stdout, stderr) =>
       if code is 0
         if activateOnSuccess
@@ -169,7 +172,7 @@ class PackageManager
         @emitPackageEvent 'installed', pack
       else
         atom.packages.activatePackage(name) if activateOnFailure
-        error = new Error("Installing \u201C#{name}@#{version}\u201D failed.")
+        error = new Error("Installing \u201C#{packageRef}\u201D failed.")
         error.stdout = stdout
         error.stderr = stderr
         error.packageInstallError = not theme

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -288,7 +288,7 @@ SyncSettings =
   installMissingPackages: (packages, cb) ->
     pending=0
     for pkg in packages
-      continue if atom.packages.isPackageLoaded(pkg.name)
+      continue if atom.packages.isPackageLoaded(pkg.name) and not pkg.apmInstallSource
       pending++
       @installPackage pkg, ->
         pending--

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -191,8 +191,8 @@ SyncSettings =
   getPackages: ->
     packages = []
     for own name, info of atom.packages.getLoadedPackages()
-      {name, version, theme} = info.metadata
-      packages.push({name, version, theme})
+      {name, version, theme, apmInstallSource} = info.metadata
+      packages.push({name, version, theme, apmInstallSource})
     _.sortBy(packages, 'name')
 
   restore: (cb=null) ->

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -288,7 +288,8 @@ SyncSettings =
   installMissingPackages: (packages, cb) ->
     pending=0
     for pkg in packages
-      continue if atom.packages.isPackageLoaded(pkg.name) and not pkg.apmInstallSource
+      continue if atom.packages.isPackageLoaded(pkg.name) and
+        (!!pkg.apmInstallSource is !!atom.packages.getLoadedPackage(pkg.name).metadata.apmInstallSource)
       pending++
       @installPackage pkg, ->
         pending--


### PR DESCRIPTION
It looked like the `update` function in `package-manager.coffee` isn't actually being called anywhere, so I wasn't sure how to integrate changes to it. It also looked like none of the tests went that deep into whether or not a package is being synced, so I wasn't sure if a test should be written for this or how you would like it done.

Much to my dismay apm doesn't seem to accept commit refs when installing from git, so I don't believe we can guarantee a particular version, but this is working for me.

Please let me know if I missed anything in the contributing guide, or if you would like me to make any changes.

Fixes #298.
