### PR TITLE
Save ALL of the packages

### DIFF
--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -190,8 +190,8 @@ SyncSettings =
 
   getPackages: ->
     packages = []
-    for own name, info of atom.packages.getLoadedPackages()
-      {name, version, theme} = info.metadata
+    for own name, info of atom.packages.getAvailablePackageMetadata()
+      {name, version, theme} = info
       packages.push({name, version, theme})
     _.sortBy(packages, 'name')
 


### PR DESCRIPTION
I have a few packages that i really like, but that i don't use constantly, so i usually keep them disabled.
When i restored my settings from another computer and i went to activate such packages, i noticed that **they weren't installed**.

Now sync-settings saves **all** of the packages, including the disabled ones, which do still remain disabled (thanks to `core.disabledPackages` in `config.cson`), but also get installed.

I'd personally prefer sync-settings to also save my disabled packages, and i think most people would too.