### PR TITLE
use token from package settings before checking environment variable

### DIFF
--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -50,7 +50,7 @@ SyncSettings =
     return gistId
 
   getPersonalAccessToken: ->
-    token = process.env.GITHUB_TOKEN or atom.config.get 'sync-settings.personalAccessToken'
+    token = atom.config.get('sync-settings.personalAccessToken') or process.env.GITHUB_TOKEN
     if token
       token = token.trim()
     return token


### PR DESCRIPTION
Fixes #366.