### PR TITLE
Fix "Remove Obsolete Packages" setting

### DIFF
--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -234,7 +234,7 @@ SyncSettings =
             if atom.config.get('sync-settings.syncPackages')
               callbackAsync = true
               @installMissingPackages JSON.parse(file.content), cb
-              if atom.config.get('sync-settings.removeObsoletePackage')
+              if atom.config.get('sync-settings.removeObsoletePackages')
                 @removeObsoletePackages JSON.parse(file.content), cb
 
           when 'keymap.cson'


### PR DESCRIPTION
This fixes a typo in the config key within the restore process which prevents this from ever executing.