### PR TITLE
Fix to handle setting keys/property names with `.`

### DIFF
--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -295,6 +295,7 @@ SyncSettings =
 
   applySettings: (pref, settings) ->
     for key, value of settings
+      key = key.replace /\./g, "\\."
       keyPath = "#{pref}.#{key}"
       isColor = false
       if _.isObject(value)


### PR DESCRIPTION
:bug: sync-settings does not handle property names with `.` properly. Fix by escaping `.` with `\.`.

*Current Config (on an out of sync node)*

```yaml
  core:
    customFileTypes:
      "source.ini": [
        ".hgrc"
      ]
```

*Backed up Config (YAML Equivalent)*

```yaml
  core:
    customFileTypes:
      "source.ini": [
        ".hgrc",
        ".flowconfig"
      ]
```

*Config after restore (no change)*
```yaml
  core:
    customFileTypes:
      "source.ini": [
        ".hgrc"
      ]
```

Possibly fixes #358 - see below
Property with name `a.b\\.c` is restored as expected.

