### PR TITLE
Option to automatically trigger backup on config change

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -72,4 +72,8 @@ module.exports = {
     type: 'boolean'
     default: false
     order: 15
+  automaticallyBackUpChangedConfig:
+    type: 'boolean'
+    default: false
+    order: 16
 }

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -219,7 +219,7 @@ SyncSettings =
     @tryAutoBackup() if savedConfigFile
 
   handleConfigChanged: ->
-    changed = @getFilteredSettings() != @lastSettings
+    changed = @getFilteredSettings() isnt @lastSettings
     @tryAutoBackup() if changed
 
   viewBackup: ->


### PR DESCRIPTION
This PR adds an option to automatically trigger backup when:
- a save event is triggered for any file in the config folder
- `config.cson` is changed programmatically
- any package is activated or deactivated

I'm also collecting all event bindings in an object, so they can cleaned up on deactivation and program exit.

Resolves #27, resolves #317