### PR TITLE
redact parts of the personal access token

### DIFF
--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -262,7 +262,7 @@ SyncSettings =
 
   createClient: ->
     token = @getPersonalAccessToken()
-    console.debug "Creating GitHubApi client with token = #{token}"
+    console.debug "Creating GitHubApi client with token = #{token.substr(0, 4)}...#{token.substr(-4, 4)}"
     github = new GitHubApi
       version: '3.0.0'
       # debug: true


### PR DESCRIPTION
Logging the full personal access token is a security-leak hazard, even
if it's useful for debugging. So let's redact parts of it, so we have
enough to reasonably validate the API-token. Copy/paste errors are more
likely in the beginning and end than the middle.