### PR TITLE
Fix init script spec with Atom 1.25

### DIFF
--- a/spec/sync-settings-spec.coffee
+++ b/spec/sync-settings-spec.coffee
@@ -145,7 +145,7 @@ describe "SyncSettings", ->
           , (err, res) ->
             expect(res.files['styles.less']).not.toBeDefined()
 
-      it "back up the user init.coffee file", ->
+      it "back up the user init script file", ->
         atom.config.set('sync-settings.syncInit', true)
         run (cb) ->
           SyncSettings.backup cb
@@ -153,9 +153,9 @@ describe "SyncSettings", ->
           run (cb) =>
             SyncSettings.createClient().gists.get({id: @gistId}, cb)
           , (err, res) ->
-            expect(res.files['init.coffee']).toBeDefined()
+            expect(res.files[path.basename(atom.getUserInitScriptPath())]).toBeDefined()
 
-      it "don't back up the user init.coffee file", ->
+      it "don't back up the user init script file", ->
         atom.config.set('sync-settings.syncInit', false)
         run (cb) ->
           SyncSettings.backup cb
@@ -163,7 +163,7 @@ describe "SyncSettings", ->
           run (cb) =>
             SyncSettings.createClient().gists.get({id: @gistId}, cb)
           , (err, res) ->
-            expect(res.files['init.coffee']).not.toBeDefined()
+            expect(res.files[path.basename(atom.getUserInitScriptPath())]).not.toBeDefined()
 
       it "back up the user snippets", ->
         atom.config.set('sync-settings.syncSnippets', true)


### PR DESCRIPTION
ref: https://github.com/atom-community/sync-settings/pull/403#pullrequestreview-97902873

In my environment, both init.coffee and init.js exists. 
```
  it "back up the user init.coffee file", ->
        atom.config.set('sync-settings.syncInit', true)
        run (cb) ->
          SyncSettings.backup cb
```
this test backups init.js instead of init.coffee, so my test fails locally.

Use atom.getUserInitScriptPath() to detect what file is expected to backup.