### PR TITLE
do not crash on undefined token

### DIFF
--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -262,7 +262,12 @@ SyncSettings =
 
   createClient: ->
     token = @getPersonalAccessToken()
-    console.debug "Creating GitHubApi client with token = #{token.substr(0, 4)}...#{token.substr(-4, 4)}"
+
+    if token
+      console.debug "Creating GitHubApi client with token = #{token.substr(0, 4)}...#{token.substr(-4, 4)}"
+    else
+      console.debug "Creating GitHubApi client without token"
+
     github = new GitHubApi
       version: '3.0.0'
       # debug: true


### PR DESCRIPTION
It seems we can get undefined returned here, which currently makes us
crash. So let's avoid trying to slice the string in that case, and just
report that there's no token instead.

Fixes #409.