### PR TITLE
ensure fetched files contain valid JSON before using them to restore config

### DIFF
--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -223,6 +223,16 @@ SyncSettings =
         atom.notifications.addError "sync-settings: Error retrieving your settings. ("+message+")"
         return
 
+      # check if the JSON files are parsable
+      for own filename, file of res.files
+        if filename is 'settings.json' or filename is 'packages.json'
+          try
+            JSON.parse(file.content)
+          catch e
+            atom.notifications.addError "sync-settings: Error parsing the fetched JSON file '"+filename+"'. ("+e+")"
+            cb?()
+            return
+
       callbackAsync = false
 
       for own filename, file of res.files

--- a/spec/sync-settings-spec.coffee
+++ b/spec/sync-settings-spec.coffee
@@ -256,6 +256,25 @@ describe "SyncSettings", ->
               expect(SyncSettings.fileContent("#{atom.getConfigDirPath()}/#{file}")).toBe("# #{file} (not found) ")
               fs.unlink "#{atom.getConfigDirPath()}/#{file}"
 
+      fit "skips the restore due to invalid json", ->
+        atom.config.set('sync-settings.syncSettings', true)
+        atom.config.set 'sync-settings.extraFiles', ['packages.json']
+        atom.config.set "some-dummy", false
+        run (cb) ->
+          SyncSettings.backup cb
+        , ->
+          atom.config.set "some-dummy", true
+          atom.notifications.clear()
+
+          run (cb) ->
+            SyncSettings.restore cb
+          , ->
+            expect(atom.notifications.getNotifications().length).toEqual 1
+            expect(atom.notifications.getNotifications()[0].getType()).toBe('error')
+            # the value should not be restored
+            # since the restore valid to parse the input as valid json
+            expect(atom.config.get "some-dummy").toBeTruthy()
+
     describe "::check for update", ->
 
       beforeEach ->

--- a/spec/sync-settings-spec.coffee
+++ b/spec/sync-settings-spec.coffee
@@ -256,7 +256,7 @@ describe "SyncSettings", ->
               expect(SyncSettings.fileContent("#{atom.getConfigDirPath()}/#{file}")).toBe("# #{file} (not found) ")
               fs.unlink "#{atom.getConfigDirPath()}/#{file}"
 
-      fit "skips the restore due to invalid json", ->
+      it "skips the restore due to invalid json", ->
         atom.config.set('sync-settings.syncSettings', true)
         atom.config.set 'sync-settings.extraFiles', ['packages.json']
         atom.config.set "some-dummy", false


### PR DESCRIPTION
Fixes #417, #416, #413, #384, #368, #362, #315.

All of these reports are `Uncaught SyntaxError` when invoking `JSON.parse` with content retrieved from the Gist which is either the `settings.json` or `packages.json` file. I don't know if in each case the content was altered to be invalid JSON or if there is a case where this packages uploads invalid JSON.

Anyway this patch catches this problem before starting to replace any configuration in the `restore` call in case either of the files is invalid. The problem results in an `error` notification to make it visible to the user.

* The first commit adds the spec (which is expected to fail CI).
* The second commits adds the check of the input data to be valid JSON (which should then make the spec pass on CI).