### PR TITLE
Add ignore unfamiliar files setting

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -130,6 +130,11 @@ const config = {
 		default: false,
 		description: "Mute 'Latest backup is already applied' message.",
 	},
+	ignoreUnfamiliarFiles: {
+		description: 'Ignore files in Extra Files and Extra Files Glob that are not in both local and backup on Check Backup.',
+		type: 'boolean',
+		default: false,
+	},
 	hiddenSettings: {
 		title: 'Hidden Settings',
 		type: 'object',

--- a/lib/sync-settings.js
+++ b/lib/sync-settings.js
@@ -98,6 +98,14 @@ module.exports = class SyncSettings {
 				return
 			}
 
+			if (diffData.files && atom.config.get('sync-settings.ignoreUnfamiliarFiles')) {
+				if (!diffData.updated) {
+					diffData.files = null
+				} else {
+					delete diffData.file.added
+					delete diffData.file.deleted
+				}
+			}
 			const hasDiff = diffData.settings || diffData.packages || diffData.files
 
 			// disregard package version changes when `Install Latest Version` setting is true


### PR DESCRIPTION
Add "Ignore Unfamiliar Files" setting to ignore files that are not in both the backup and local folder on Check Backup.