### PR TITLE
fix: fix check backup with only change in package versions

### DIFF
--- a/lib/sync-settings.js
+++ b/lib/sync-settings.js
@@ -86,7 +86,14 @@ module.exports = class SyncSettings {
 				return
 			}
 
-			if (diffData.settings || diffData.packages || diffData.files) {
+			const hasDiff = diffData.settings || diffData.packages || diffData.files
+
+			// disregard package version changes when `Install Latest Version` setting is true
+			let hideVersionsUpdate = atom.config.get('sync-settings.installLatestVersion')
+			hideVersionsUpdate = hideVersionsUpdate && !diffData.settings && !diffData.files && diffData.packages
+			hideVersionsUpdate = hideVersionsUpdate && !diffData.packages.added && !diffData.packages.deleted && diffData.packages.updated
+
+			if (hasDiff && !hideVersionsUpdate) {
 				const lastBackupTime = config.getLastBackupTime(data)
 				notify.newerBackup(autoCheck, lastBackupTime, data.time)
 				return

--- a/spec/sync-settings-spec.js
+++ b/spec/sync-settings-spec.js
@@ -932,7 +932,52 @@ describe('syncSettings', () => {
 				expect(atom.notifications.getNotifications()[0].getType()).toBe('warning')
 			})
 
-			it('ignores on up-to-date backup', async () => {
+			it('success on only package versions diff', async () => {
+				atom.config.set('sync-settings.installLatestVersion', true)
+				spyOn(syncSettings, 'getDiffData').and.returnValue({
+					packages: {
+						updated: {
+							'sync-settings': { version: '1.0.0' },
+						},
+					},
+				})
+				await syncSettings.checkBackup()
+
+				expect(atom.notifications.getNotifications().length).toBe(1)
+				expect(atom.notifications.getNotifications()[0].getType()).toBe('success')
+			})
+
+			it('warning on not only package versions diff', async () => {
+				atom.config.set('sync-settings.installLatestVersion', true)
+				spyOn(syncSettings, 'getDiffData').and.returnValue({
+					packages: {
+						added: {
+							'sync-settings': { version: '1.0.0' },
+						},
+					},
+				})
+				await syncSettings.checkBackup()
+
+				expect(atom.notifications.getNotifications().length).toBe(1)
+				expect(atom.notifications.getNotifications()[0].getType()).toBe('warning')
+			})
+
+			it('warning on only package versions diff without installLatestVersion', async () => {
+				atom.config.set('sync-settings.installLatestVersion', false)
+				spyOn(syncSettings, 'getDiffData').and.returnValue({
+					packages: {
+						updated: {
+							'sync-settings': { version: '1.0.0' },
+						},
+					},
+				})
+				await syncSettings.checkBackup()
+
+				expect(atom.notifications.getNotifications().length).toBe(1)
+				expect(atom.notifications.getNotifications()[0].getType()).toBe('warning')
+			})
+
+			it('success on up-to-date backup', async () => {
 				await syncSettings.backup()
 				atom.notifications.clear()
 				await syncSettings.checkBackup()


### PR DESCRIPTION
This does not prevent the diff view from showing differences in package versions but only prevents the check backup call from failing if `Always Install Latest Version` is checked and the only difference is package versions.

discussion: https://github.com/atom-community/sync-settings/issues/497#issuecomment-595080704