### PR TITLE
Wait for location service

### DIFF
--- a/lib/sync-settings.js
+++ b/lib/sync-settings.js
@@ -41,19 +41,31 @@ module.exports = class SyncSettings {
 
 	useLocationService (locationService) {
 		this.locationService = locationService
+		if (this.waitingForLocationService) {
+			this.waitingForLocationService(locationService)
+		}
 	}
 
 	disposeLocationService () {
 		this.locationService = null
 	}
 
-	getBackupLocation () {
-		if (atom.config.get('sync-settings.useOtherLocation')) {
-			if (this.locationService) {
-				return this.locationService
-			}
-		} else {
+	async getBackupLocation (waitForLocationService) {
+		if (!atom.config.get('sync-settings.useOtherLocation')) {
 			return require('./location/gist.js')
+		}
+
+		if (this.locationService) {
+			return this.locationService
+		}
+
+		if (waitForLocationService) {
+			return new Promise(resolve => {
+				this.waitingForLocationService = (locationService) => {
+					resolve(locationService)
+					this.waitingForLocationService = null
+				}
+			})
 		}
 
 		notify.noLocationService()
@@ -62,7 +74,7 @@ module.exports = class SyncSettings {
 	async checkBackup (autoCheck) {
 		const signal = notify.signal('Sync-Settings: Checking backup...')
 		try {
-			const backupLocation = this.getBackupLocation()
+			const backupLocation = await this.getBackupLocation(autoCheck)
 			if (!backupLocation) {
 				return
 			}
@@ -112,7 +124,7 @@ module.exports = class SyncSettings {
 	async createBackup () {
 		const signal = notify.signal('Sync-Settings: Creating new backup...')
 		try {
-			const backupLocation = this.getBackupLocation()
+			const backupLocation = await this.getBackupLocation()
 			if (!backupLocation) {
 				return
 			}
@@ -130,7 +142,7 @@ module.exports = class SyncSettings {
 	async fork () {
 		const signal = notify.signal('Sync-Settings: Forking backup...')
 		try {
-			const backupLocation = this.getBackupLocation()
+			const backupLocation = await this.getBackupLocation()
 			if (!backupLocation) {
 				return
 			}
@@ -161,7 +173,7 @@ module.exports = class SyncSettings {
 			if (cancel) {
 				return
 			}
-			const backupLocation = this.getBackupLocation()
+			const backupLocation = await this.getBackupLocation()
 			if (!backupLocation) {
 				return
 			}
@@ -201,7 +213,7 @@ module.exports = class SyncSettings {
 				}
 			}
 
-			const backupLocation = this.getBackupLocation()
+			const backupLocation = await this.getBackupLocation()
 			if (!backupLocation) {
 				return
 			}
@@ -244,7 +256,7 @@ module.exports = class SyncSettings {
 	async restore () {
 		const signal = notify.signal('Sync-Settings: Restoring backup...')
 		try {
-			const backupLocation = this.getBackupLocation()
+			const backupLocation = await this.getBackupLocation()
 			if (!backupLocation) {
 				return
 			}
@@ -304,7 +316,7 @@ module.exports = class SyncSettings {
 	}
 
 	async viewBackup () {
-		const backupLocation = this.getBackupLocation()
+		const backupLocation = await this.getBackupLocation()
 		if (!backupLocation) {
 			return
 		}

--- a/lib/views/diff-view.js
+++ b/lib/views/diff-view.js
@@ -33,7 +33,7 @@ module.exports = class DiffView {
 		this.update({ diff: null, error: null })
 		const signal = notify.signal('Sync-Settings: Diffing backup...')
 		try {
-			const backupLocation = this.syncSettings.getBackupLocation()
+			const backupLocation = await this.syncSettings.getBackupLocation()
 			if (!backupLocation) {
 				this.update({ diff: null, error: 'Error retrieving your backup' })
 				return


### PR DESCRIPTION
Wait for location service before performing auto check. This will prevent a race condition between the auto check and the location package loading.

If there is no location package installed it will not do the auto check but still show an error when manually checking or trying to sync.

Fixes https://github.com/UziTech/sync-settings-folder-location/issues/16