### PR TITLE
feat: add provider for packages to blacklist keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,3 +218,53 @@ module.exports = {
   },
 }
 ```
+
+## Sync-Settings Service
+
+Sync-Settings provides a service that allows other packages to interact with Sync-Settings:
+
+### Example:
+
+Add the keywords `sync-settings` and `location` and add the `consumeServices` property to your `package.json` file.
+
+```json
+// package.json
+  ...
+  "main": "./main.js",
+  ...
+  "consumeServices": {
+    "sync-settings": {
+      "versions": {
+        "1.0.0": "syncSettingsService"
+      }
+    }
+  },
+  ...
+```
+
+Then add the `syncSettingsService` function to your `main.js` file (where your `activate` function is for Atom to activate your package)
+
+```js
+// main.js
+  ...
+  activate () {
+    ...
+  },
+
+  syncSettingsService (service) {
+    // call service functions to interact with Sync-Settings
+  },
+  ...
+```
+
+### Service Functions
+
+The following functions are available on the service:
+
+#### `hideSettings(string | string[])`
+
+Add keys to the blacklist so they won't be backed up or overwritten on restore.
+
+```js
+service.hideSettings(['package-name.config-key', 'package-name.another-config-key'])
+```

--- a/lib/main.js
+++ b/lib/main.js
@@ -81,4 +81,14 @@ module.exports = {
 			this.locationService = null
 		})
 	},
+
+	provideSyncSettingsService () {
+		return {
+			hideSettings (keys) {
+				if (this.syncSettings) {
+					this.syncSettings.hideSettings(keys)
+				}
+			},
+		}
+	},
 }

--- a/lib/sync-settings.js
+++ b/lib/sync-settings.js
@@ -17,6 +17,8 @@ const DiffView = require('./views/diff-view')
 
 module.exports = class SyncSettings {
 	constructor () {
+		this.settingsToHide = []
+
 		config.updateLegacyConfigSettings()
 
 		if (atom.config.get('sync-settings.checkForUpdatedBackup')) {
@@ -37,6 +39,13 @@ module.exports = class SyncSettings {
 
 	disposeBusySignal () {
 		notify.disposeBusySignal()
+	}
+
+	hideSettings (keys) {
+		if (!Array.isArray(keys)) {
+			keys = [keys]
+		}
+		this.settingsToHide.push(...keys)
 	}
 
 	useLocationService (locationService) {
@@ -290,7 +299,7 @@ module.exports = class SyncSettings {
 			}
 
 			if (backupData.settings) {
-				utils.updateSettings(backupData.settings)
+				utils.updateSettings(backupData.settings, this.settingsToHide)
 			}
 
 			if (backupData.packages) {
@@ -344,7 +353,7 @@ module.exports = class SyncSettings {
 		}
 
 		if (atom.config.get('sync-settings.syncSettings')) {
-			data.settings = utils.getFilteredSettings()
+			data.settings = utils.getFilteredSettings(this.settingsToHide)
 		}
 		if (atom.config.get('sync-settings.syncPackages') || atom.config.get('sync-settings.syncThemes')) {
 			data.packages = utils.getPackages()

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -140,19 +140,20 @@ module.exports = {
 		return packages
 	},
 
-	updateSettings (settings) {
+	updateSettings (settings, settingsToHide = []) {
 		if (!('*' in settings)) {
 			// backed up before v2.0.2
 			settings = { '*': settings }
 		}
-		this.addFilteredSettings(settings)
+		this.addFilteredSettings(settings, settingsToHide)
 		for (const scopeSelector in settings) {
 			atom.config.set(null, settings[scopeSelector], { scopeSelector })
 		}
 	},
 
-	addFilteredSettings (settings) {
+	addFilteredSettings (settings, settingsToHide = []) {
 		const blacklistedKeys = [
+			...settingsToHide,
 			...REMOVE_KEYS,
 			...atom.config.get('sync-settings.blacklistedKeys') || [],
 		]
@@ -166,13 +167,14 @@ module.exports = {
 		return settings
 	},
 
-	getFilteredSettings () {
+	getFilteredSettings (settingsToHide = []) {
 		// _.clone() doesn't deep clone thus we are using JSON parse trick
 		const settings = JSON.parse(JSON.stringify({
 			'*': atom.config.settings,
 			...atom.config.scopedSettingsStore.propertiesForSource(atom.config.mainSource),
 		}))
 		const blacklistedKeys = [
+			...settingsToHide,
 			...REMOVE_KEYS,
 			...atom.config.get('sync-settings.blacklistedKeys') || [],
 		]

--- a/package.json
+++ b/package.json
@@ -42,6 +42,13 @@
       }
     }
   },
+  "providedServices": {
+    "sync-settings": {
+      "versions": {
+        "1.0.0": "provideSyncSettingsService"
+      }
+    }
+  },
   "dependencies": {
     "@octokit/rest": "^18.0.0",
     "deep-object-diff": "^1.1.0",

--- a/spec/sync-settings-spec.js
+++ b/spec/sync-settings-spec.js
@@ -106,6 +106,18 @@ describe('syncSettings', () => {
 			expect(settings['*'].package.dummy2).toBe(true)
 		})
 
+		it("doesn't back up string hidden setting", async () => {
+			syncSettings.hideSettings('package.dummy')
+			atom.config.set('package.dummy', true)
+			atom.config.set('package.dummy2', true)
+			await syncSettings.backup()
+			const data = await backupLocation.get()
+			const settings = JSON.parse(data.files['settings.json'].content)
+
+			expect(settings['*'].package.dummy).not.toBeDefined()
+			expect(settings['*'].package.dummy2).toBe(true)
+		})
+
 		it("back up hidden setting parent if key doesn't exist", async () => {
 			syncSettings.hideSettings(['package.dummy.dummy2'])
 			atom.config.set('package.dummy', true)

--- a/spec/utils-spec.js
+++ b/spec/utils-spec.js
@@ -244,6 +244,20 @@ describe('utils', () => {
 			expect(settings['*'].package['setting.with.dots']).toBe('')
 			expect(settings['*'].packge.very.nested.setting).toBe(true)
 		})
+
+		it('adds settingsToHide keys', function () {
+			atom.config.set('dummy', false)
+			atom.config.set('package.dummy', 0)
+			atom.config.set('package.setting\\.with\\.dots', '')
+			atom.config.set('packge.very.nested.setting', true)
+
+			const settings = utils.addFilteredSettings({ '*': {} }, ['dummy', 'package.dummy', 'package.setting\\.with\\.dots', 'packge.very.nested.setting'])
+
+			expect(settings['*'].dummy).toBe(false)
+			expect(settings['*'].package.dummy).toBe(0)
+			expect(settings['*'].package['setting.with.dots']).toBe('')
+			expect(settings['*'].packge.very.nested.setting).toBe(true)
+		})
 	})
 
 	describe('getFilteredSettings', () => {
@@ -255,6 +269,20 @@ describe('utils', () => {
 			atom.config.set('packge.very.nested.setting', true)
 
 			const settings = utils.getFilteredSettings()
+
+			expect(settings['*'].dummy).not.toBeDefined()
+			expect(settings['*'].package.dummy).not.toBeDefined()
+			expect(settings['*'].package['setting.with.dots']).not.toBeDefined()
+			expect(settings['*'].packge.very.nested.setting).not.toBeDefined()
+		})
+
+		it('remove settingsToHide keys', function () {
+			atom.config.set('dummy', false)
+			atom.config.set('package.dummy', 0)
+			atom.config.set('package.setting\\.with\\.dots', '')
+			atom.config.set('packge.very.nested.setting', true)
+
+			const settings = utils.getFilteredSettings(['dummy', 'package.dummy', 'package.setting\\.with\\.dots', 'packge.very.nested.setting'])
 
 			expect(settings['*'].dummy).not.toBeDefined()
 			expect(settings['*'].package.dummy).not.toBeDefined()


### PR DESCRIPTION
Add service provider so other packages can list keys to be hidden.

If a package has settings that contain sensitive information or don't make sense to backup they can consume the `sync-settings` service and use the `hideSettings()` function to tell Sync-Settings to ignore those keys when backing up or restoring.