### PR TITLE
fix: gist auto converting EOL causes wrong diffs result

### DIFF
--- a/lib/sync-settings.js
+++ b/lib/sync-settings.js
@@ -616,7 +616,7 @@ module.exports = class SyncSettings {
 				const localFile = localData.files ? localData.files[fileName] : null
 				if (backupFile && localFile) {
 					const isBinary = isBinaryPath(fileName)
-					const localContent = localFile.content.toString(isBinary ? 'base64' : 'utf8')
+					const localContent = localFile.content.toString(isBinary ? 'base64' : 'utf8').replace(/\r\n/g, '\n')
 					const backupContent = backupFile.content.toString(isBinary ? 'base64' : 'utf8')
 					if (localContent !== backupContent) {
 						let content

--- a/spec/sync-settings-spec.js
+++ b/spec/sync-settings-spec.js
@@ -912,6 +912,26 @@ describe('syncSettings', () => {
 				},
 			})
 		})
+
+		it('same files with diff EOL', async () => {
+			const diffData = await syncSettings.getDiffData({
+				files: {
+					added: { content: 'added\r\n' },
+					updated: { content: 'updated\r\n' },
+				},
+			}, {
+				files: {
+					added: { content: 'added\n' },
+					updated: { content: 'updated\n' },
+				},
+			})
+
+			expect(diffData).toEqual({
+				settings: null,
+				packages: null,
+				files: null,
+			})
+		})
 	})
 
 	describe('check for update', () => {


### PR DESCRIPTION
I found out Gist will auto convert EOL characters of uploaded files from `\r\n` to `\n`.
It will cause sync-settings getting wrong diffs result every time comparing with local Windows files.


![image](https://user-images.githubusercontent.com/798943/90049980-2c3ea000-dd08-11ea-8eaa-2d25baaa3adb.png)
