### PR TITLE
fix: keep track of location services and always use last loaded

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -2,6 +2,8 @@ const { CompositeDisposable, Disposable } = require('atom')
 const { config } = require('./config')
 
 module.exports = {
+	locationServices: [],
+
 	config,
 
 	activate (state) {
@@ -23,8 +25,8 @@ module.exports = {
 				if (this.busySignal) {
 					this.syncSettings.useBusySignal(this.busySignal)
 				}
-				if (this.locationService) {
-					this.syncSettings.useLocationService(this.locationService)
+				if (this.locationServices.length > 0) {
+					this.syncSettings.useLocationService(this.locationServices[0])
 				}
 
 				this.disposables.add(
@@ -47,7 +49,16 @@ module.exports = {
 	},
 
 	deactivate () {
-		this.disposables.dispose()
+		if (this.disposables) {
+			this.disposables.dispose()
+		}
+		if (this.syncSettings) {
+			this.syncSettings.disposeBusySignal()
+			this.syncSettings.disposeLocationService()
+			this.syncSettings = null
+		}
+		this.locationServices = []
+		this.busySignal = null
 	},
 
 	serialize () {},
@@ -66,19 +77,23 @@ module.exports = {
 	},
 
 	syncSettingslocationService (locationService) {
-		if (this.locationService) {
+		if (this.locationServices.length > 0) {
 			require('./utils/notify').multipleLocationServices()
-			console.error(new Error('Sync-Settings: Multiple Location Services'))
+			console.error(new Error('Sync-Settings: Multiple Location Services'), locationService)
 		}
 		if (this.syncSettings) {
 			this.syncSettings.useLocationService(locationService)
 		}
-		this.locationService = locationService
+		this.locationServices.unshift(locationService)
 		return new Disposable(() => {
+			this.locationServices = this.locationServices.filter(l => l !== locationService)
 			if (this.syncSettings) {
-				this.syncSettings.disposeLocationService()
+				if (this.locationServices.length > 0) {
+					this.syncSettings.useLocationService(this.locationServices[0])
+				} else {
+					this.syncSettings.disposeLocationService()
+				}
 			}
-			this.locationService = null
 		})
 	},
 }

--- a/lib/sync-settings.js
+++ b/lib/sync-settings.js
@@ -58,8 +58,9 @@ module.exports = class SyncSettings {
 
 	useLocationService (locationService) {
 		this.locationService = locationService
-		if (this.waitingForLocationService) {
-			this.waitingForLocationService(locationService)
+		if (this.resolveLocationService) {
+			this.resolveLocationService(locationService)
+			this.resolveLocationService = null
 		}
 	}
 
@@ -78,10 +79,7 @@ module.exports = class SyncSettings {
 
 		if (waitForLocationService) {
 			return new Promise(resolve => {
-				this.waitingForLocationService = (locationService) => {
-					resolve(locationService)
-					this.waitingForLocationService = null
-				}
+				this.resolveLocationService = resolve
 			})
 		}
 

--- a/lib/utils/notify.js
+++ b/lib/utils/notify.js
@@ -187,7 +187,7 @@ Do you want to back up this file anyway?`.trim(),
 
 	multipleLocationServices () {
 		notify.error('Sync-Settings: Multiple Location Services', {
-			description: 'You have more than one location service installed. Only the first one loaded will be used.',
+			description: 'You have more than one location service installed. Only the last one loaded will be used.',
 			dismissable: true,
 		})
 	},

--- a/spec/main-spec.js
+++ b/spec/main-spec.js
@@ -1,0 +1,78 @@
+const SyncSettings = require('../lib/sync-settings')
+const main = require('../lib/main')
+
+describe('main', () => {
+	beforeEach(() => {
+		main.deactivate()
+	})
+
+	describe('syncSettingslocationService', () => {
+		it('add/remove locationServices', () => {
+			const locationService1 = Symbol('locationService1')
+			const locationService2 = Symbol('locationService2')
+			const locationService3 = Symbol('locationService3')
+			expect(main.locationServices).toEqual([])
+			const removeLocationService1 = main.syncSettingslocationService(locationService1)
+			expect(main.locationServices).toEqual([locationService1])
+			const removeLocationService2 = main.syncSettingslocationService(locationService2)
+			expect(main.locationServices).toEqual([locationService2, locationService1])
+			const removeLocationService3 = main.syncSettingslocationService(locationService3)
+			expect(main.locationServices).toEqual([locationService3, locationService2, locationService1])
+			removeLocationService2.dispose()
+			expect(main.locationServices).toEqual([locationService3, locationService1])
+			removeLocationService1.dispose()
+			expect(main.locationServices).toEqual([locationService3])
+			removeLocationService3.dispose()
+			expect(main.locationServices).toEqual([])
+		})
+
+		it('set locationService after activate', async () => {
+			spyOn(SyncSettings.prototype, 'useLocationService')
+			const locationService1 = Symbol('locationService1')
+			main.syncSettingslocationService(locationService1)
+			expect(SyncSettings.prototype.useLocationService).not.toHaveBeenCalled()
+			main.activate()
+			await main.activationPromise
+			expect(SyncSettings.prototype.useLocationService).toHaveBeenCalledWith(locationService1)
+		})
+
+		it('set locationService if already activated', async () => {
+			spyOn(SyncSettings.prototype, 'useLocationService')
+			const locationService1 = Symbol('locationService1')
+			main.activate()
+			await main.activationPromise
+			main.syncSettingslocationService(locationService1)
+			expect(SyncSettings.prototype.useLocationService).toHaveBeenCalledWith(locationService1)
+		})
+
+		it('set locationService to last added', async () => {
+			spyOn(SyncSettings.prototype, 'useLocationService')
+			spyOn(SyncSettings.prototype, 'disposeLocationService')
+			main.activate()
+			await main.activationPromise
+			const locationService1 = Symbol('locationService1')
+			const locationService2 = Symbol('locationService2')
+			const locationService3 = Symbol('locationService3')
+			expect(SyncSettings.prototype.useLocationService).toHaveBeenCalledTimes(0)
+			const removeLocationService1 = main.syncSettingslocationService(locationService1)
+			expect(SyncSettings.prototype.useLocationService).toHaveBeenCalledTimes(1)
+			expect(SyncSettings.prototype.useLocationService.calls.mostRecent().args).toEqual([locationService1])
+			const removeLocationService2 = main.syncSettingslocationService(locationService2)
+			expect(SyncSettings.prototype.useLocationService).toHaveBeenCalledTimes(2)
+			expect(SyncSettings.prototype.useLocationService.calls.mostRecent().args).toEqual([locationService2])
+			const removeLocationService3 = main.syncSettingslocationService(locationService3)
+			expect(SyncSettings.prototype.useLocationService).toHaveBeenCalledTimes(3)
+			expect(SyncSettings.prototype.useLocationService.calls.mostRecent().args).toEqual([locationService3])
+			removeLocationService2.dispose()
+			expect(SyncSettings.prototype.useLocationService).toHaveBeenCalledTimes(4)
+			expect(SyncSettings.prototype.useLocationService.calls.mostRecent().args).toEqual([locationService3])
+			removeLocationService3.dispose()
+			expect(SyncSettings.prototype.useLocationService).toHaveBeenCalledTimes(5)
+			expect(SyncSettings.prototype.useLocationService.calls.mostRecent().args).toEqual([locationService1])
+
+			expect(SyncSettings.prototype.disposeLocationService).toHaveBeenCalledTimes(0)
+			removeLocationService1.dispose()
+			expect(SyncSettings.prototype.disposeLocationService).toHaveBeenCalledTimes(1)
+		})
+	})
+})


### PR DESCRIPTION
Keep track of all location services provided and always use the last one. This allows switching location services when one is deactivated without needing to restart Atom.